### PR TITLE
Bat-client related stubs [WIP]

### DIFF
--- a/__snapshots__/wallet.js
+++ b/__snapshots__/wallet.js
@@ -22,3 +22,70 @@ exports['wallet create 1'] = {
   },
   "publishers": {}
 }
+
+exports['wallet recovery recovers 1'] = {
+  "cache": {
+    "ledgerVideos": {}
+  },
+  "ledger": {
+    "synopsis": {
+      "options": {
+        "_a": 7000,
+        "_b": 1000,
+        "scorekeeper": "concave",
+        "_d": 0.000033333333333333335,
+        "numFrames": 30,
+        "frameSize": 86400000,
+        "emptyScores": {
+          "concave": 0,
+          "visits": 0
+        },
+        "_b2": 1000000,
+        "scorekeepers": [
+          "concave",
+          "visits"
+        ],
+        "_a2": 14000,
+        "_a4": 28000,
+        "minPublisherVisits": 0,
+        "minPublisherDuration": 0
+      }
+    },
+    "about": {
+      "synopsisOptions": {
+        "_a": 7000,
+        "_b": 1000,
+        "scorekeeper": "concave",
+        "_d": 0.000033333333333333335,
+        "numFrames": 30,
+        "frameSize": 86400000,
+        "emptyScores": {
+          "concave": 0,
+          "visits": 0
+        },
+        "_b2": 1000000,
+        "scorekeepers": [
+          "concave",
+          "visits"
+        ],
+        "_a2": 14000,
+        "_a4": 28000,
+        "minPublisherVisits": 0,
+        "minPublisherDuration": 0
+      },
+      "synopsis": []
+    },
+    "info": {
+      "created": true,
+      "bravery": {
+        "fee": {
+          "currency": "USD",
+          "amount": 10
+        }
+      }
+    }
+  },
+  "about": {
+    "preferences": {}
+  }
+}

--- a/js/wallet.js
+++ b/js/wallet.js
@@ -66,6 +66,7 @@ class JS extends Wallet {
             return self.defaultContribution
           }
           case settings.PAYMENTS_ENABLED:
+          case settings.PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED:
           {
             return true
           }
@@ -73,21 +74,30 @@ class JS extends Wallet {
       }
     })
 
-    // browser-laptop modules
     this.ledger = require('../browser-laptop/app/browser/api/ledger')
     this.ledgerStatuses = require('../browser-laptop/app/common/constants/ledgerStatuses')
 
-    // stubbed ledgerApi functions
     this.recoverWalletCallback = sinon.stub(this.ledger, 'recoverWalletCallback').callsFake(function (error, result) {
       self.state = self.ledger.onWalletRecovery(self.state, error, result)
     })
 
-    this.onBraveryPropertiesCallback = sinon.stub(this.ledger, 'onBraveryPropertiesCallback').callsFake(function (error, result) {
-      self.state = self.ledger.onBraveryProperties(self.state, error, result)
+    this.onInitReadAction = sinon.stub(this.ledger, 'onInitReadAction').callsFake(function (state, parsedData) {
+      // self.state = self.ledger.onInitRead(state, parsedData)
     })
 
-    this.onInitReadAction = sinon.stub(this.ledger, 'onInitReadAction').callsFake(function (state, parsedData) {
-      // self.state = self.ledger.onInitRead(state, {})
+    this.getWalletPropertiesCallback = sinon.stub(this.ledger, 'getWalletPropertiesCallback').callsFake(function (err, body) {
+      if (err) {
+        return self.state
+      }
+      self.state = this.ledger.onWalletProperties(self.state, body)
+      return self.state
+    })
+
+    this.onBraveryPropertiesCallback = sinon.stub(this.ledger, 'onBraveryPropertiesCallback').callsFake(function (error, result) {
+      self.state = self.state
+        .setIn(['ledger', 'info'], Immutable.Map())
+        .setIn(['ledger', 'info', 'created'], true)
+      self.state = self.ledger.onBraveryProperties(self.state, error, result)
     })
 
     this.onLedgerCallbackAction = sinon.stub(this.ledger, 'onLedgerCallbackAction').callsFake(function (result, delayTime) {
@@ -99,12 +109,23 @@ class JS extends Wallet {
     })
 
     this.initAccessStatePath = sinon.stub(this.ledger, 'initAccessStatePath').callsFake(function (state, statePath) {
-      self.ledger.onInitReadAction(self.stateFile)
+      self.state = self.ledger.onInitReadAction(self.stateFile)
       return state
+    })
+
+    this.extendBraveryProps = sinon.stub(this.ledger, 'extendBraveryProps').callsFake(function (bravery) {
+      return {
+        fee: {
+          currency: 'USD',
+          amount: self.defaultContribution
+        }
+      }
     })
   }
 
   beforeEach (mockery) {
+    this.state = null
+    this.stateFile = null
     this.ledger.setSynopsis(null)
   }
 
@@ -118,10 +139,23 @@ class JS extends Wallet {
     return this.ledger.getSynopsis()
   }
 
+  createWalletState () {
+    return this.ledger.enable(defaultAppState)
+  }
+
+  setPaymentInfo (amount) {
+    this.ledger.setPaymentInfo(amount)
+  }
+
   clientInit () {
     this.state = this.ledger.init(defaultAppState)
+    this.state = this.ledger.enable(this.state)
     this.state = this.ledger.onBootStateFile(this.state)
-    return this.state
+    this.setPaymentInfo(this.defaultContribution)
+  }
+
+  recoverWallet (key) {
+    return this.ledger.recoverKeys(this.state, false, key)
   }
 }
 

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -30,4 +30,12 @@ describe('wallet', function () {
     const result = lib.createWallet()
     snapshot(this.test.fullTitle(), result)
   })
+
+  describe('recovery', function () {
+    it('recovers', function () {
+      lib.clientInit()
+      const result = lib.recoverWallet('wasp broken strong analyst until tray olympic arrow input bicycle gun settle prepare tissue road try sustain husband width brave section obey country area')
+      snapshot(this.test.fullTitle(), result)
+    })
+  })
 })


### PR DESCRIPTION
This PR aims to be able to have the bat-client fully functional in the spec tests (IE it is able to initialize, populate with bravery properties, send/receive server responses etc)

So far this PR adds a few different handles to skirt around appActions calls, as well as stubs `muonWriter` so as to internalize the `stateFile` as a member of the Wallet/Lib class.