### PR TITLE
Adding stand-ins for roundtrip, requests, initial mock bat-client responses

### DIFF
--- a/js/wallet.js
+++ b/js/wallet.js
@@ -6,8 +6,9 @@
 
 const Immutable = require('immutable')
 
+const sinon = require('sinon')
 const Wallet = require('../abs/wallet')
-const request = require('../lib/request')
+const {request, roundtrip} = require('../lib/request')
 
 const defaultAppState = Immutable.fromJS({
   cache: {
@@ -41,6 +42,9 @@ class JS extends Wallet {
     })
 
     this.ledger = require('../browser-laptop/app/browser/api/ledger')
+    this.roundtrip = sinon.stub(this.ledger, 'roundtrip').callsFake(function (params, options, callback) {
+      roundtrip(params, options, callback)
+    })
   }
 
   beforeEach (mockery) {

--- a/lib/data/ledger-state.json
+++ b/lib/data/ledger-state.json
@@ -1,0 +1,110 @@
+{
+  "personaId": "312c959c-e9cf-42b0-95af-715d9547aeea",
+  "options": {
+    "debugP": false,
+    "loggingP": false,
+    "rulesTestP": false,
+    "verboseP": false,
+    "server": {
+      "protocol": "https:",
+      "slashes": true,
+      "auth": null,
+      "host": "ledger.mercury.basicattentiontoken.org",
+      "port": null,
+      "hostname": "ledger.mercury.basicattentiontoken.org",
+      "hash": null,
+      "search": null,
+      "query": null,
+      "pathname": "/",
+      "path": "/",
+      "href": "https://ledger.mercury.basicattentiontoken.org/"
+    },
+    "version": "v2",
+    "environment": "production",
+    "prefix": "/v2"
+  },
+  "ballots": [],
+  "transactions": [],
+  "properties": {
+    "setting": "adFree",
+    "fee": {
+      "currency": "BAT",
+      "amount": 7.5
+    },
+    "days": 30,
+    "wallet": {
+      "keyinfo": {
+        "seed": {
+          "0": 14,
+          "1": 182,
+          "2": 213,
+          "3": 46,
+          "4": 183,
+          "5": 45,
+          "6": 142,
+          "7": 189,
+          "8": 223,
+          "9": 216,
+          "10": 163,
+          "11": 26,
+          "12": 21,
+          "13": 112,
+          "14": 78,
+          "15": 22,
+          "16": 204,
+          "17": 38,
+          "18": 136,
+          "19": 222,
+          "20": 127,
+          "21": 240,
+          "22": 178,
+          "23": 64,
+          "24": 89,
+          "25": 46,
+          "26": 237,
+          "27": 247,
+          "28": 48,
+          "29": 220,
+          "30": 144,
+          "31": 1
+        }
+      },
+      "paymentId": "7ec50587-223f-4189-a377-9d570a17ad1c",
+      "addresses": {
+        "BAT": "0x9076CE8d5e6aD43EBA94c7A909572DE0A39E7eFC",
+        "BTC": "1NyTZUmwLJoDNhvJwKGCAAKPhbnGo4SVTd",
+        "CARD_ID": "6c4dd79e-1008-4381-89d0-d6078963bef6",
+        "ETH": "0x9076CE8d5e6aD43EBA94c7A909572DE0A39E7eFC",
+        "LTC": "LLcZ6fFz9zdrMzf3f9ewno3xe6LPXoeVxK"
+      }
+    }
+  },
+  "reconcileStamp": 1529211991783,
+  "memos": [
+    "{\"who\":\"sync\",\"what\":{\"reconcileStamp\":1527829588048,\"reconcileDate\":\"2018-06-01T05:06:28.048Z\"},\"when\":1526619988048}"
+  ],
+  "ruleset": [
+    {
+      "condition": "/^[a-z][a-z].gov$/.test(SLD)",
+      "consequent": "QLD + '.' + SLD",
+      "description": "governmental sites"
+    },
+    {
+      "condition": "TLD === 'gov' || /^go.[a-z][a-z]$/.test(TLD) || /^gov.[a-z][a-z]$/.test(TLD)",
+      "consequent": "SLD",
+      "description": "governmental sites"
+    },
+    {
+      "condition": "SLD === 'keybase.pub'",
+      "consequent": "QLD + '.' + SLD",
+      "description": "keybase users"
+    },
+    {
+      "condition": true,
+      "consequent": "SLD",
+      "description": "the default rule"
+    }
+  ],
+  "persona": "{\"userId\":\"312c959ce9cf2b095af715d9547aeea\",\"registrarVK\":\"==========ANONLOGIN_VK_BEG==========\n5Zo7fjdryszdwgAZO+HiK18yErXRoPvRkmYmo4E2UQV 4NMDAdwHg0z3LdGN3KkOoFLbza3SpeUWBcMKOUvJ8O1 1\n7MpAGVMgs+tuMQs4pH+nKUh0M+rl21RyUAdhRHKGhq4 5LXnl7uUw0XwaSTIojyDh4hODTEcT5BAiAhPCGIItDM 1\n2qtVvVwfxlDGzPSXXl0Ms94eycXiUJpthRp6uAjrjW8 Auhpv58KOuncZfXB1eekbOwTXloSAgPPRJ3A1g2a1MZ 1\n41nN9zSpWB6xfefhy/BWOouZnE5Vz+Akgtu3WavASEJ AF4pxNogZT38xdPdxe51RIGaFXKNVj3K2vbfN3uzI1T 1\n31ND6Q8qewDElWUU88rMWn4RZl95sjbSvoimlfsVFEg 8VjyRwkfd4dWwMQhShAIiyY0L9tOiJIR4PWlRIwyQs6 wLm/Ph3gh2ZtdqNbGJIcQM1LoCr+23zELEwUKvAnSL 1sWQdlB2UL0xSqgNcb9NObxiSof322GgHUg2nq43Y4l 1 0\n===========ANONLOGIN_VK_END==========\",\"masterUserToken\":\"==========ANONLOGIN_CRED_BEG==========\\n312c959ce9cf2b095af715d9547aeea\\nA0C0dESg6ONR8f+P8mk4X12cbOmADZg5Vm2QPv6wlHk\\nA7DlEe2qHj/r3IktOmq1pE5gjK9+r/oGUz3Q528p9qk 8BvyryzRdi1INPGMMEg25VNacZFQEkKHTmLAhP0VWwO 1\\n8oU7/SrWETtNui8VybQXr7op324hNbVo7Gmb4K6MQ0C\\n3aBoXdyy5FSDfF40iGqq/o/qsHGFR24g++6NTMdUfZ/\\n===========ANONLOGIN_CRED_END==========\"}",
+  "bootStamp": 1526619991783
+}

--- a/lib/data/responses.json
+++ b/lib/data/responses.json
@@ -1,0 +1,111 @@
+{
+  "/v3/publisher/timestamp": {
+    "timestamp": "6556256801271054343"
+  },
+  "/v2/registrar/persona": {
+    "payload": {
+      "adFree": {
+        "currency": "BAT",
+        "fee": {
+          "BAT": 10
+        },
+        "choices": {
+          "BAT": [
+            5,
+            7.5,
+            10,
+            12.5,
+            15,
+            17.5,
+            20,
+            25,
+            50
+          ]
+        },
+        "range": {
+          "BAT": [
+            5,
+            100
+          ]
+        },
+        "days": 30
+      }
+    },
+    "registrarVK": "==========ANONLOGIN_VK_BEG==========\n5Zo7fjdryszdwgAZO+HiK18yErXRoPvRkmYmo4E2UQV 4NMDAdwHg0z3LdGN3KkOoFLbza3SpeUWBcMKOUvJ8O1 1\n7MpAGVMgs+tuMQs4pH+nKUh0M+rl21RyUAdhRHKGhq4 5LXnl7uUw0XwaSTIojyDh4hODTEcT5BAiAhPCGIItDM 1\n2qtVvVwfxlDGzPSXXl0Ms94eycXiUJpthRp6uAjrjW8 Auhpv58KOuncZfXB1eekbOwTXloSAgPPRJ3A1g2a1MZ 1\n41nN9zSpWB6xfefhy/BWOouZnE5Vz+Akgtu3WavASEJ AF4pxNogZT38xdPdxe51RIGaFXKNVj3K2vbfN3uzI1T 1\n31ND6Q8qewDElWUU88rMWn4RZl95sjbSvoimlfsVFEg 8VjyRwkfd4dWwMQhShAIiyY0L9tOiJIR4PWlRIwyQs6 wLm/Ph3gh2ZtdqNbGJIcQM1LoCr+23zELEwUKvAnSL 1sWQdlB2UL0xSqgNcb9NObxiSof322GgHUg2nq43Y4l 1 0\n===========ANONLOGIN_VK_END=========="
+  },
+  "/v2/wallet/balance": {
+    "altcurrency": "BAT",
+    "probi": "0",
+    "balance": "0.0000",
+    "unconfirmed": "0.0000",
+    "rates": {
+      "BTC": "0.00004800",
+      "ETH": 0.0005088939893845933,
+      "LTC": 0.0025576784426820476,
+      "USD": 0.352857648,
+      "EUR": 0.29858461316111995
+    },
+    "parameters": {
+      "adFree": {
+        "currency": "BAT",
+        "fee": {
+          "BAT": 10
+        },
+        "choices": {
+          "BAT": [
+            5,
+            7.5,
+            10,
+            12.5,
+            15,
+            17.5,
+            20,
+            25,
+            50
+          ]
+        },
+        "range": {
+          "BAT": [
+            5,
+            100
+          ]
+        },
+        "days": 30
+      }
+    },
+    "addresses": {
+      "BAT": "0x9076CE8d5e6aD43EBA94c7A909572DE0A39E7eFC",
+      "BTC": "1NyTZUmwLJoDNhvJwKGCAAKPhbnGo4SVTd",
+      "CARD_ID": "6c4dd79e-1008-4381-89d0-d6078963bef6",
+      "ETH": "0x9076CE8d5e6aD43EBA94c7A909572DE0A39E7eFC",
+      "LTC": "LLcZ6fFz9zdrMzf3f9ewno3xe6LPXoeVxK"
+    }
+  },
+  "/promo/custom-headers": [
+    {
+      "domains": [
+        "marketwatch.com",
+        "barrons.com"
+      ],
+      "headers": {
+        "X-Brave-Partner": "dowjones"
+      },
+      "cookieNames": [],
+      "expiration": 31536000000
+    },
+    {
+      "domains": [
+        "townsquareblogs.com",
+        "tasteofcountry.com",
+        "ultimateclassicrock.com",
+        "xxlmag.com",
+        "popcrush.com"
+      ],
+      "headers": {
+        "X-Brave-Partner": "townsquare"
+      },
+      "cookieNames": [],
+      "expiration": 31536000000
+    }
+  ]
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,17 +4,49 @@
 
 'use strict'
 
-const req = require('request')
+const urlFormat = require('url').format
 const underscore = require('underscore')
+const responses = require('./data/responses')
 const urlParse = require('../browser-laptop/app/common/urlParse')
 
-module.exports = (options, callback) => {
-  var params
-  var responseType = options.responseType || 'text'
+const hostLookup = {
+  'ledger.brave.com': 'ledger-proxy.privateinternetaccess.com',
+  'ledger.mercury.basicattentiontoken.org': 'mercury-proxy.privateinternetaccess.com'
+}
 
-  if (typeof options === 'string') options = { url: options }
+const getPath = (url) => {
+  let path = null
+
+  if (url.match(/\/v2\/wallet\/(.*)\/balance/)) {
+    return '/v2/wallet/balance'
+  } else if (url.match(/\/v2\/registrar\/persona/)) {
+    return '/v2/registrar/persona'
+  }
+
+  const parsedPath = urlParse(url).path
+
+  if (responses.hasOwnProperty(parsedPath)) {
+    return parsedPath
+  }
+
+  return path
+}
+
+const request = (options, callback) => {
+  let params
+  let path = getPath(options.url)
+  const responseBody = path != null ? responses[path] : {}
+
+  if (!path) {
+    callback(null, {statusCode: 200}, responseBody)
+  }
+
+  if (typeof options === 'string') {
+    options = { url: options }
+  }
   params = underscore.defaults(underscore.pick(options, [ 'method', 'headers' ]), { headers: {} })
   params.headers['accept-encoding'] = ''
+
   if (options.payload) {
     underscore.extend(params, {
       payload: JSON.stringify(options.payload),
@@ -28,22 +60,89 @@ module.exports = (options, callback) => {
 
   if (process.env.NODE_ENV === 'development' &&
       urlParse(options.url).protocol === 'http:') {
-    console.log('WARNING: requesting non-HTTPS URL', options.url)
   }
 
-  req({url: options.url, qs: params}, (err, response, body) => {
-    var rsp = underscore.pick(response || {}, [ 'statusCode', 'statusMessage', 'headers', 'httpVersionMajor', 'httpVersionMinor' ])
+  callback(null, {statusCode: 200}, responseBody)
+}
 
-    underscore.keys(rsp.headers).forEach((header) => {
-      if (Array.isArray(rsp.headers[header])) rsp.headers[header] = rsp.headers[header][0]
-    })
+const roundtrip = (params, options, callback) => {
+  const binaryP = options.binaryP
+  let parts = typeof params.server === 'string' ? urlParse(params.server)
+    : typeof params.server !== 'undefined' ? params.server
+      : typeof options.server === 'string' ? urlParse(options.server) : options.server
 
-    if (err) return callback(err, rsp)
+  if (!params.method) {
+    params.method = 'GET'
+  }
+  parts = underscore.extend(underscore.pick(parts, ['protocol', 'hostname', 'port']),
+    underscore.omit(params, ['headers', 'payload', 'timeout']))
 
-    underscore.defaults(rsp, { statusMessage: '', httpVersionMajor: 1, httpVersionMinor: 1 })
-    if (responseType !== 'text') body = Buffer.from(body, 'binary')
-    if (responseType === 'blob') body = 'data:' + rsp.headers['content-type'] + ';base64,' + body.toString('base64')
+  if (params.useProxy) {
+    if (hostLookup.hasOwnProperty(parts.hostname)) {
+      parts.hostname = hostLookup[parts.hostname]
+    }
+  }
 
-    callback(null, rsp, body)
+  const i = parts.path.indexOf('?')
+  if (i !== -1) {
+    parts.pathname = parts.path.substring(0, i)
+    parts.search = parts.path.substring(i)
+  } else {
+    parts.pathname = parts.path
+  }
+
+  if (options.windowP) {
+    roundTripFromWindow({url: urlFormat(parts), verboseP: options.verboseP}, callback)
+    return
+  }
+
+  options = {
+    url: urlFormat(parts),
+    method: params.method,
+    payload: params.payload,
+    responseType: binaryP ? 'binary' : 'text',
+    headers: underscore.defaults(params.headers || {}, {
+      'content-type': 'application/json; charset=utf-8',
+      'user-agent': 'Brave/FakeUserAz'
+    }),
+    verboseP: options.verboseP
+  }
+
+  request(options, callback)
+}
+
+const roundTripFromWindow = (params, callback) => {
+  if (!callback) {
+    return
+  }
+
+  if (!params || !params.url) {
+    callback(new Error('Url is missing'))
+    return
+  }
+
+  fetchPublisherInfo(params.url, {
+    method: 'GET',
+    responseType: 'text',
+    headers: {
+      'content-type': 'application/json; charset=utf-8'
+    }
+  }, (error, body) => {
+    if (error) {
+      return callback(error)
+    }
+
+    return callback(null, {statusCode: 200}, body)
   })
+}
+
+const fetchPublisherInfo = (url, options, callback) => {
+  callback(null, {})
+}
+
+module.exports = {
+  request,
+  roundtrip,
+  roundTripFromWindow,
+  fetchPublisherInfo
 }


### PR DESCRIPTION
This PR includes the addition of the `data` folder under `lib` which includes:

1. A file called `responses.json` which contains captured responses from `bat-client` endpoints with the path as the key
2. A file called `ledger-state.json` which contains an initial ledger state. This will be loaded in to the test libs and modified in memory via a `muonWriter` stub
3. The addition of mock roundtrip functions in to `request.js`