### PR TITLE
Contributions tests now returns the ledger-info state data

### DIFF
--- a/__snapshots__/contribution.js
+++ b/__snapshots__/contribution.js
@@ -1,39 +1,100 @@
-exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution before time to reconcile 1'] = []
-
-exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution at reconcile with enough funds and met browsing requirements 1'] = [
-  {
-    "viewingId": "2c61e750-a08f-4098-bcd4-5006525ebb25",
-    "contribution": {
-      "fiat": {
-        "amount": 10,
-        "currency": "BAT"
-      },
-      "rates": {
-        "EUR": 0.2190412601894385,
-        "USD": 0.25554448620000003,
-        "BCH": 0.00033478155925657733,
-        "BTC": 0.00004514,
-        "DASH": 0.00102477365436275,
-        "BTG": 0.009849390389672483,
-        "XRP": 0.5155155155155156,
-        "ETH": 0.0005365421680470907,
-        "LTC": 0.0029730119786404966
-      },
-      "altcurrency": "BAT",
-      "probi": "20000000000000000000"
-    },
-    "submissionStamp": 1530120720753,
-    "votes": 58,
-    "count": 58,
-    "ballots": {
-      "brianbondy.com": 19,
-      "bumpsmack.com": 26,
-      "clifton.io": 13
-    },
-    "names": {}
+exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution before time to reconcile 1'] = {
+  "paymentId": "7ec50587-223f-4189-a377-9d570a17ad1c",
+  "created": true,
+  "creating": false,
+  "reconcileFrequency": 30,
+  "reconcileStamp": 1528948800000,
+  "passphrase": "proof stock music predict throw exercise another spot tunnel minimum tomorrow obscure saddle fortune walk always attract fortune acquire lend author quantum orchard retire",
+  "bravery": {
+    "setting": "adFree",
+    "days": 30,
+    "fee": {
+      "currency": "BAT",
+      "amount": 10
+    }
   }
-]
+}
 
-exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution at reconcile with not enough funds 1'] = []
+exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution at reconcile with enough funds and met browsing requirements 1'] = {
+  "paymentId": "7ec50587-223f-4189-a377-9d570a17ad1c",
+  "created": true,
+  "creating": false,
+  "reconcileFrequency": 30,
+  "reconcileStamp": 1528948800000,
+  "passphrase": "proof stock music predict throw exercise another spot tunnel minimum tomorrow obscure saddle fortune walk always attract fortune acquire lend author quantum orchard retire",
+  "bravery": {
+    "setting": "adFree",
+    "days": 30,
+    "fee": {
+      "currency": "BAT",
+      "amount": 10
+    }
+  },
+  "transactions": [
+    {
+      "viewingId": "2c61e750-a08f-4098-bcd4-5006525ebb25",
+      "contribution": {
+        "fiat": {
+          "amount": 10,
+          "currency": "BAT"
+        },
+        "rates": {
+          "EUR": 0.2190412601894385,
+          "USD": 0.25554448620000003,
+          "BCH": 0.00033478155925657733,
+          "BTC": 0.00004514,
+          "DASH": 0.00102477365436275,
+          "BTG": 0.009849390389672483,
+          "XRP": 0.5155155155155156,
+          "ETH": 0.0005365421680470907,
+          "LTC": 0.0029730119786404966
+        },
+        "altcurrency": "BAT",
+        "probi": "20000000000000000000"
+      },
+      "submissionStamp": 1530120720753,
+      "votes": 58,
+      "count": 58,
+      "ballots": {
+        "bumpsmack.com": 26,
+        "clifton.io": 13,
+        "brianbondy.com": 19
+      },
+      "names": {}
+    }
+  ]
+}
 
-exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution at reconcile with enough funds but not met browsing requirements 1'] = []
+exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution at reconcile with not enough funds 1'] = {
+  "paymentId": "7ec50587-223f-4189-a377-9d570a17ad1c",
+  "created": true,
+  "creating": false,
+  "reconcileFrequency": 30,
+  "reconcileStamp": 1528948800000,
+  "passphrase": "proof stock music predict throw exercise another spot tunnel minimum tomorrow obscure saddle fortune walk always attract fortune acquire lend author quantum orchard retire",
+  "bravery": {
+    "setting": "adFree",
+    "days": 30,
+    "fee": {
+      "currency": "BAT",
+      "amount": 10
+    }
+  }
+}
+
+exports['contribution (contribution tests run for approximately 15 seconds) Tries to run contribution at reconcile with enough funds but not met browsing requirements 1'] = {
+  "paymentId": "7ec50587-223f-4189-a377-9d570a17ad1c",
+  "created": true,
+  "creating": false,
+  "reconcileFrequency": 30,
+  "reconcileStamp": 1528948800000,
+  "passphrase": "proof stock music predict throw exercise another spot tunnel minimum tomorrow obscure saddle fortune walk always attract fortune acquire lend author quantum orchard retire",
+  "bravery": {
+    "setting": "adFree",
+    "days": 30,
+    "fee": {
+      "currency": "BAT",
+      "amount": 10
+    }
+  }
+}

--- a/js/contribution.js
+++ b/js/contribution.js
@@ -117,14 +117,6 @@ class JS extends Contribution {
     this.ledger.setBreakRun(false)
   }
 
-  staticizeBallots () {
-    let transaction = this.state.getIn(['ledger', 'info', 'transactions']).toJS()
-    transaction[0].ballots['brianbondy.com'] = 19
-    transaction[0].ballots['bumpsmack.com'] = 26
-    transaction[0].ballots['clifton.io'] = 13
-    this.state = this.state.setIn(['ledger', 'info', 'transactions'], transaction)
-  }
-
   createWallet () {
     this.setState(this.ledger.enable(this.state))
   }
@@ -136,7 +128,7 @@ class JS extends Contribution {
     this.fuzzPublishers()
     this.state = ledgerState.setInfoProp(this.state, 'reconcileStamp', 1719633600000) // 06/29/2024
     this.ledger.run(this.state, 0)
-    return ledgerState.getInfoProp(this.state, 'transactions') || []
+    return this.getInfo(this.state) || {}
   }
 
   contributionMinusFunds () {
@@ -147,7 +139,7 @@ class JS extends Contribution {
     this.fuzzPublishers()
     this.state = ledgerState.setInfoProp(this.state, 'reconcileStamp', 1528948800000)
     this.ledger.run(this.state, 0)
-    return ledgerState.getInfoProp(this.state, 'transactions') || []
+    return this.getInfo(this.state) || {}
   }
 
   contributionAdequateFundsReqMet () {
@@ -157,8 +149,7 @@ class JS extends Contribution {
     this.fuzzPublishers()
     this.state = ledgerState.setInfoProp(this.state, 'reconcileStamp', 1528948800000)
     this.ledger.run(this.state, 0)
-    this.staticizeBallots()
-    return ledgerState.getInfoProp(this.state, 'transactions') || []
+    return this.getInfo(this.state) || {}
   }
 
   contributionAdequateFundsReqNotMet () {
@@ -167,7 +158,7 @@ class JS extends Contribution {
     this.addPublishersToLedger()
     this.state = ledgerState.setInfoProp(this.state, 'reconcileStamp', 1528948800000)
     this.ledger.run(this.state, 0)
-    return ledgerState.getInfoProp(this.state, 'transactions') || []
+    return this.getInfo(this.state) || {}
   }
 }
 

--- a/lib/helpers/snapshotContributionStatics.js
+++ b/lib/helpers/snapshotContributionStatics.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const staticizeState = (infoState) => {
+  infoState = _staticizeBallots(infoState)
+  infoState = _staticizeReconcileStamp(infoState)
+  return _staticizePassphrase(infoState)
+}
+
+const _staticizeBallots = (infoState) => {
+  if (infoState.getIn(['transactions'])) {
+    let transaction = infoState.getIn(['transactions']).toJS()
+    transaction[0].ballots['brianbondy.com'] = 19
+    transaction[0].ballots['bumpsmack.com'] = 26
+    transaction[0].ballots['clifton.io'] = 13
+    return infoState.setIn(['transactions'], transaction)
+  }
+  return infoState
+}
+
+const _staticizePassphrase = (infoState) => {
+  return infoState.getIn(['passphrase'])
+    ? infoState.setIn(['passphrase'], 'proof stock music predict throw exercise another spot tunnel minimum tomorrow obscure saddle fortune walk always attract fortune acquire lend author quantum orchard retire')
+    : infoState
+}
+
+const _staticizeReconcileStamp = (infoState) => {
+  return infoState.getIn(['reconcileStamp'])
+    ? infoState.setIn(['reconcileStamp'], 1528948800000)
+    : infoState
+}
+
+module.exports = {
+  staticizeState
+}

--- a/test/contribution.js
+++ b/test/contribution.js
@@ -7,6 +7,7 @@
 /* global describe, before, beforeEach, after, afterEach, it */
 
 const helper = require('../helper')
+const contributionHelper = require('../lib/helpers/snapshotContributionStatics')
 const snapshot = require('snap-shot-it')
 const mockery = require('mockery')
 
@@ -30,23 +31,27 @@ describe('contribution (contribution tests run for approximately 15 seconds)', f
   })
 
   it('Tries to run contribution before time to reconcile', async function () {
-    const result = lib.contributionBeforeTime()
+    let result = lib.contributionBeforeTime()
+    result = contributionHelper.staticizeState(result)
     snapshot(this.test.fullTitle(), result)
   })
 
   it('Tries to run contribution at reconcile with enough funds and met browsing requirements', function () {
-    const result = lib.contributionAdequateFundsReqMet()
+    let result = lib.contributionAdequateFundsReqMet()
+    result = contributionHelper.staticizeState(result)
     snapshot(this.test.fullTitle(), result)
   })
 
   it('Tries to run contribution at reconcile with not enough funds', function () {
     lib.changeSetting('PAYMENTS_CONTRIBUTION_AMOUNT', 100)
-    const result = lib.contributionMinusFunds()
+    let result = lib.contributionMinusFunds()
+    result = contributionHelper.staticizeState(result)
     snapshot(this.test.fullTitle(), result)
   })
 
   it('Tries to run contribution at reconcile with enough funds but not met browsing requirements', function () {
-    const result = lib.contributionAdequateFundsReqNotMet()
+    let result = lib.contributionAdequateFundsReqNotMet()
+    result = contributionHelper.staticizeState(result)
     snapshot(this.test.fullTitle(), result)
   })
 })


### PR DESCRIPTION
Previously return only the transactions object, the contributions test now returns the data from ['ledger', 'info'] part of state.